### PR TITLE
Added imagick and gd - necessary for using 'wp media' commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN set -ex \
             php8.2-igbinary \
             php8.2-msgpack \
             php8.2-soap \
+            php8.2-imagick \
+            php8.2-gd \
             php8.2-zip \
             openssl \
             ca-certificates \


### PR DESCRIPTION
Added the imagick and gd modules. These are necessary whenever using wp media command to regenerate thumbnails. This is a heavy process that usually is more efficient when done through the terminal. 

I built and ran the image locally - image runs fine.